### PR TITLE
:sparkles: add WETH intents for op, main, poly, arb and base

### DIFF
--- a/examples/weth.ts
+++ b/examples/weth.ts
@@ -1,0 +1,84 @@
+import { Hex, http } from "viem";
+import { mainnet, sepolia } from "viem/chains";
+import { wethTools } from "../src/shared/weth";
+import AgentekToolkit from "../src/ai-sdk/toolkit";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { CoreMessage, CoreTool, generateText } from "ai";
+
+async function main() {
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+  });
+
+  let privateKey = process.env.PRIVATE_KEY;
+
+  if (!privateKey) {
+    privateKey = generatePrivateKey();
+    console.log("PRIVATE_KEY:", privateKey);
+  }
+
+  const account = privateKeyToAccount(privateKey as Hex);
+
+  const chains = [mainnet, sepolia];
+  console.log("ACCOUNT:", account.address);
+  console.log(
+    "CHAINS:",
+    chains.map((chain) => chain.id),
+  );
+
+  const toolkit = new AgentekToolkit({
+    transports: [http(), http()],
+    chains,
+    accountOrAddress: account,
+    tools: [...wethTools()],
+  });
+
+  const tools = toolkit.getTools();
+
+  console.log("NUMBER OF TOOLS", Object.keys(tools).length);
+  console.log("AVAILABLE TOOLS:", Object.keys(tools));
+
+  const messages = [
+    {
+      role: "user",
+      content: "First wrap 0.01 ETH to WETH on Sepolia and then unwrap it.",
+    },
+  ] as CoreMessage[];
+
+  messages.forEach((message) => {
+    console.log(`\n[${message.role.toUpperCase()}]`);
+    console.log(message.content);
+  });
+
+  const response = await generateText({
+    model: openrouter("openai/gpt-4o-mini"),
+    system: "",
+    messages,
+    maxSteps: 5,
+    tools: tools as Record<string, CoreTool<any, any>>,
+    experimental_activeTools: Object.keys(tools),
+  });
+
+  response.response.messages.forEach((message) => {
+    console.log(`\n[${message.role.toUpperCase()}]`);
+    if (typeof message.content === "string") {
+      console.log(`${message.content}`);
+    } else {
+      message.content.forEach((content) => {
+        if (content.type === "text") {
+          console.log(`${content.text}`);
+        } else if (content.type === "tool-call") {
+          console.log(`[Tool:${content.toolName}]`);
+          console.log(`${JSON.stringify(content.args, null, 2)}`);
+        } else if (content.type === "tool-result") {
+          console.log(`\n---\n${content.result}`);
+        }
+      });
+    }
+  });
+}
+
+main()
+  .then((_o) => console.log("--fin--"))
+  .catch((e) => console.error(e));

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -3,6 +3,7 @@ import { ensTools } from "./ens";
 import { dexscreenerTools } from "./dexscreener";
 import { rpcTools } from "./rpc";
 import { uniV3Tools } from "./uniV3";
+import { wethTools } from "./weth";
 
 const allTools = () => {
   return [
@@ -11,6 +12,7 @@ const allTools = () => {
     ...dexscreenerTools(),
     ...rpcTools(),
     ...uniV3Tools(),
+    ...wethTools(),
   ];
 };
 

--- a/src/shared/weth/constants.ts
+++ b/src/shared/weth/constants.ts
@@ -1,0 +1,32 @@
+import { mainnet, optimism, arbitrum, polygon } from "viem/chains";
+
+export const supportedChains = [mainnet, optimism, arbitrum, polygon];
+
+export const WETH_ADDRESS = {
+  [mainnet.id]: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+  [optimism.id]: "0x4200000000000000000000000000000000000006",
+  [arbitrum.id]: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+  [polygon.id]: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+} as const;
+
+export const wethAbi = [
+  {
+    type: "function",
+    name: "deposit",
+    stateMutability: "payable",
+    outputs: [],
+    inputs: [],
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    stateMutability: "nonpayable",
+    outputs: [],
+    inputs: [
+      {
+        name: "_amount",
+        type: "uint256",
+      },
+    ],
+  },
+];

--- a/src/shared/weth/constants.ts
+++ b/src/shared/weth/constants.ts
@@ -1,6 +1,20 @@
-import { mainnet, optimism, arbitrum, polygon, base } from "viem/chains";
+import {
+  mainnet,
+  optimism,
+  arbitrum,
+  polygon,
+  base,
+  sepolia,
+} from "viem/chains";
 
-export const supportedChains = [mainnet, optimism, arbitrum, polygon, base];
+export const supportedChains = [
+  mainnet,
+  optimism,
+  arbitrum,
+  polygon,
+  base,
+  sepolia,
+];
 
 export const WETH_ADDRESS = {
   [mainnet.id]: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
@@ -8,6 +22,7 @@ export const WETH_ADDRESS = {
   [arbitrum.id]: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
   [polygon.id]: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
   [base.id]: "0x4200000000000000000000000000000000000006",
+  [sepolia.id]: "0x7b79995e5f793a07bc00c21412e50ecae098e7f9",
 } as const;
 
 export const wethAbi = [

--- a/src/shared/weth/constants.ts
+++ b/src/shared/weth/constants.ts
@@ -1,12 +1,13 @@
-import { mainnet, optimism, arbitrum, polygon } from "viem/chains";
+import { mainnet, optimism, arbitrum, polygon, base } from "viem/chains";
 
-export const supportedChains = [mainnet, optimism, arbitrum, polygon];
+export const supportedChains = [mainnet, optimism, arbitrum, polygon, base];
 
 export const WETH_ADDRESS = {
   [mainnet.id]: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   [optimism.id]: "0x4200000000000000000000000000000000000006",
   [arbitrum.id]: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
   [polygon.id]: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+  [base.id]: "0x4200000000000000000000000000000000000006",
 } as const;
 
 export const wethAbi = [

--- a/src/shared/weth/index.ts
+++ b/src/shared/weth/index.ts
@@ -1,6 +1,6 @@
 import {BaseTool, createToolCollection} from "../client";
-import {depositWETHIntent, withdrawWETHIntent} from "./intents";
+import {intent_withdrawWETH, intent_depositWETH, } from "./intents";
 
 export function wethTools(): BaseTool[] {
-  return createToolCollection([depositWETHIntent, withdrawWETHIntent]);
+  return createToolCollection([intent_depositWETH, intent_withdrawWETH]);
 }

--- a/src/shared/weth/index.ts
+++ b/src/shared/weth/index.ts
@@ -1,0 +1,6 @@
+import {BaseTool, createToolCollection} from "../client";
+import {depositWETHIntent, withdrawWETHIntent} from "./intents";
+
+export function wethTools(): BaseTool[] {
+  return createToolCollection([depositWETHIntent, withdrawWETHIntent]);
+}

--- a/src/shared/weth/intents.ts
+++ b/src/shared/weth/intents.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+import { AgentekClient, createTool, Intent } from "../client"; 
+import { Address, encodeFunctionData, Hex, SendTransactionParameters } from "viem";
+import { supportedChains, WETH_ADDRESS, wethAbi } from "./constants";
+
+const depositWETHParameters = z.object({
+  chainId: z.number().describe("Chain ID to deposit on"),
+  amount: z.string().describe("Amount of ETH to deposit (as a string)"),
+});
+
+const withdrawWETHParameters = z.object({
+  chainId: z.number().describe("Chain ID to withdraw on"),
+  amount: z.string().describe("Amount of WETH to withdraw (as a string)"),
+});
+
+const depositWETHChains = supportedChains;
+const withdrawWETHChains = supportedChains;
+
+export const depositWETHIntent = createTool({
+  name: "depositWETH",
+  description: "Deposit ETH into the WETH contract, receiving WETH in return",
+  supportedChains: depositWETHChains,
+  parameters: depositWETHParameters,
+  execute: async (
+    client: AgentekClient,
+    args: z.infer<typeof depositWETHParameters>,
+  ): Promise<Intent> => {
+    const { chainId, amount } = args;
+    const walletClient = client.getWalletClient(chainId);
+
+    const valueToSend = BigInt(amount);
+
+    const data = encodeFunctionData({
+      abi: wethAbi,
+      functionName: "deposit",
+      args: [],
+    });
+
+    const ops = [
+      {
+        target: WETH_ADDRESS[chainId as keyof typeof WETH_ADDRESS] as Address,
+        value: valueToSend.toString(),
+        data: data,
+      },
+    ];
+
+    if (!walletClient) {
+      return {
+        intent: `Deposit ${amount} ETH into WETH on chain ${chainId}`,
+        ops,
+        chain: chainId,
+      };
+    } else {
+        const hash = await walletClient.sendTransaction({
+          to: ops[0]!.target as Address,
+          value: BigInt(ops[0]!.value),
+          data: ops[0]!.data as Hex,
+        } as SendTransactionParameters);
+    
+    return {
+      intent: `Deposit ${amount} ETH into WETH on chain ${chainId}`,
+      ops,
+      chain: chainId,
+      hash,
+    };
+  }
+  },
+});
+
+export const withdrawWETHIntent = createTool({
+  name: "withdrawWETH",
+  description: "Withdraw WETH back to native ETH",
+  supportedChains: withdrawWETHChains,
+  parameters: withdrawWETHParameters,
+  execute: async (
+    client: AgentekClient,
+    args: z.infer<typeof withdrawWETHParameters>,
+  ): Promise<Intent> => {
+    const { chainId, amount } = args;
+
+    const walletClient = client.getWalletClient(chainId);
+    const amountToWithdraw = BigInt(amount);
+
+    const data = encodeFunctionData({
+      abi: wethAbi,
+      functionName: "withdraw",
+      args: [amountToWithdraw],
+    });
+
+    const ops = [
+      {
+        target: WETH_ADDRESS[chainId as keyof typeof WETH_ADDRESS] as Address,
+        value: "0",
+        data,
+      },
+    ];
+
+    if (!walletClient) {
+      return {
+        intent: `Withdraw ${amount} WETH to native ETH on chain ${chainId}`,
+        ops,
+        chain: chainId,
+      };
+    } else {
+      const hash = await walletClient.sendTransaction({
+        to: ops[0]!.target as Address,
+        value: BigInt(ops[0]!.value),
+        data: ops[0]!.data as Hex,
+      } as SendTransactionParameters);
+
+      return {
+        intent: `Withdraw ${amount} WETH to native ETH on chain ${chainId}`,
+        ops,
+        chain: chainId,
+        hash,
+      };
+    }
+  },
+});

--- a/src/shared/weth/intents.ts
+++ b/src/shared/weth/intents.ts
@@ -16,7 +16,7 @@ const withdrawWETHParameters = z.object({
 const depositWETHChains = supportedChains;
 const withdrawWETHChains = supportedChains;
 
-export const depositWETHIntent = createTool({
+export const intent_depositWETH = createTool({
   name: "depositWETH",
   description: "Deposit ETH into the WETH contract, receiving WETH in return",
   supportedChains: depositWETHChains,
@@ -46,7 +46,7 @@ export const depositWETHIntent = createTool({
 
     if (!walletClient) {
       return {
-        intent: `Deposit ${amount} ETH into WETH on chain ${chainId}`,
+        intent: `Deposit ${amount} ETH into WETH`,
         ops,
         chain: chainId,
       };
@@ -58,7 +58,7 @@ export const depositWETHIntent = createTool({
         } as SendTransactionParameters);
     
     return {
-      intent: `Deposit ${amount} ETH into WETH on chain ${chainId}`,
+      intent: `Deposit ${amount} ETH into WETH`,
       ops,
       chain: chainId,
       hash,
@@ -67,7 +67,7 @@ export const depositWETHIntent = createTool({
   },
 });
 
-export const withdrawWETHIntent = createTool({
+export const intent_withdrawWETH = createTool({
   name: "withdrawWETH",
   description: "Withdraw WETH back to native ETH",
   supportedChains: withdrawWETHChains,
@@ -97,7 +97,7 @@ export const withdrawWETHIntent = createTool({
 
     if (!walletClient) {
       return {
-        intent: `Withdraw ${amount} WETH to native ETH on chain ${chainId}`,
+        intent: `Withdraw ${amount} WETH to native ETH`,
         ops,
         chain: chainId,
       };
@@ -109,7 +109,7 @@ export const withdrawWETHIntent = createTool({
       } as SendTransactionParameters);
 
       return {
-        intent: `Withdraw ${amount} WETH to native ETH on chain ${chainId}`,
+        intent: `Withdraw ${amount} WETH to native ETH`,
         ops,
         chain: chainId,
         hash,


### PR DESCRIPTION
closes #3 

I noticed theres tests for the RPC and for the client, but there isn't a case of testing against chain state. I can write unit tests for this but I would want them to run against a forked instance of chain state vs mocking out the on-chain interactions. Let me know if there's appetite for that work and I can either do it in a separate PR or in this one (I tend to think it'd make sense to build out in a seperate PR and then backfill unit tests for the tools).

Also followed the general pattern for the transfer tool - let me know if there are any requested changes and appreciate your patience.