### PR TITLE
feat: response compaction, resolveToken tool, address normalization, …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,20 @@
+# Agentek TODO
+
+## Response Compaction
+
+- [x] `getAddressInternalTransactions` — Returns extremely large responses that cause downstream model context issues. Need to add pagination defaults or truncate/summarize the response to a reasonable size (e.g. return only the first N results with a `hasMore` flag).
+- [x] `getAddressBlocksValidated` — Same issue, returns massive responses that overflow model context. Needs pagination/compaction.
+- [x] `getBlock` — Returns full block data including all transactions, which is way too large for model context. Should return a compact summary (block number, timestamp, gas used, tx count) and omit the full transactions array by default.
+- [x] `getAddressNFTCollections` — Returns massive responses for addresses with many NFT collections. Needs pagination/compaction.
+
+## New Tools
+
+- [x] `resolveToken` — Resolve a token symbol (e.g. 'USDC', 'DAI', 'WETH') to its contract address, decimals, and name on a specific chain. Currently mocked in nani-model training data generation. The model needs this to chain symbol→address lookups before calling tools like `getBalanceOf`, `intentApprove`, `intentTransfer`, etc. Should support all major tokens across Ethereum, Base, Arbitrum, and Optimism. Parameters: `symbol` (string), `chainId` (number). Returns: `{ symbol, chainId, address, decimals, name }`.
+
+## Address Validation
+
+- [x] ERC20 tools (`getBalanceOf`, `getAllowance`, etc.) reject addresses with incorrect EIP-55 checksums (e.g. `0x1DB3439a...` vs correct `0x1Db3439a...`) while RPC tools (`getBalance`) accept them fine. Should normalize addresses to lowercase or proper checksum before validation so mixed-case addresses don't fail.
+
+## Chain Support
+
+- [x] `intentTransfer` — Does not support Optimism (chainId 10). Returns "Chain 10 not supported by tool intentTransfer". Should add Optimism support to all intent tools since it's a supported chain in the system.

--- a/TODO.md
+++ b/TODO.md
@@ -18,3 +18,31 @@
 ## Chain Support
 
 - [x] `intentTransfer` — Does not support Optimism (chainId 10). Returns "Chain 10 not supported by tool intentTransfer". Should add Optimism support to all intent tools since it's a supported chain in the system.
+
+## Training Data / Tool Schema Mismatches (nani-model)
+
+The following tools in `nani-model/scripts/tool-schemas.json` have interfaces that differ from the actual agentek implementations. Training data needs to be regenerated for these tools or the schemas updated.
+
+### Parameter mismatches
+
+- [ ] `getBlock` — Training data has `blockHash` (string) and `blockTag` (string, "latest"/"earliest"/"pending") parameters that do not exist in the actual tool. Actual tool only accepts `blockNumber` (number, optional) and `chainId` (number, required). Also, the actual tool now returns a compact summary (no `transactions` array, adds `transactionCount`) after the response compaction change, which training data responses don't reflect.
+
+- [ ] `getAcrossFeeQuote` — Training data uses a single `token` parameter. Actual tool uses two separate parameters: `inputToken` (origin chain token address) and `outputToken` (destination chain token address). Training data is also missing the required `recipient` parameter.
+
+- [ ] `intentDecreaseLiquidity` — Training data has `amount0Min` and `amount1Min` parameters (strings, both required). Actual tool uses `slippageTolerance` (number, optional, default 0.5) instead and computes min amounts internally. Training data required params `[tokenId, liquidity, amount0Min, amount1Min, chainId]` vs actual required `[tokenId, liquidity, chainId]`.
+
+- [ ] `intentIncreaseLiquidity` — Training data has `amount0Min` and `amount1Min` parameters (strings). Actual tool uses `slippageTolerance` (number, optional, default 0.5) instead and computes min amounts internally.
+
+- [ ] `intentTransferPosition` — Training data has a `from` parameter (string, required). Actual tool does not accept `from`; it infers the sender via `client.getAddress()`. Training data required params `[tokenId, from, to, chainId]` vs actual `[tokenId, to, chainId]`.
+
+- [ ] `getYieldTool` — Training data is missing parameters that exist in the actual tool: `maxRisk` (enum: low/medium/high), `protocol` (enum of supported protocols), `asset` (string), and `chainId` (number). These are all optional but should be in the schema so the model can use them.
+
+### Pagination parameters missing from training data
+
+- [ ] `getAddressInternalTransactions` — Actual tool now has optional `next_page_params` (string) parameter for pagination. Training data schema does not include it.
+- [ ] `getAddressBlocksValidated` — Same: actual tool now has `next_page_params` parameter.
+- [ ] `getAddressNFTCollections` — Same: actual tool now has `next_page_params` parameter.
+
+### Missing tool in training data
+
+- [ ] `resolveToken` — The tool was just added to agentek but training data `tool-schemas.json` already has a schema for it. Verify the training examples actually exercise this tool (training data was likely generated with a mock — re-generate with the real tool to ensure response format matches).

--- a/packages/shared/blockscout/tools.ts
+++ b/packages/shared/blockscout/tools.ts
@@ -70,6 +70,31 @@ export async function fetchFromBlockscoutV2(
     throw error;
   }
 }
+const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Compact a Blockscout paginated response so it fits in model context.
+ * Keeps at most `DEFAULT_PAGE_SIZE` items and surfaces a `hasMore` flag plus
+ * `next_page_params` the caller can pass verbatim to fetch the next page.
+ */
+function compactItems(response: any): any {
+  if (!response || typeof response !== "object") return response;
+
+  const items: any[] | undefined = response.items;
+  if (!Array.isArray(items)) return response;
+
+  const hasMore = items.length > DEFAULT_PAGE_SIZE || !!response.next_page_params;
+  const truncated = items.slice(0, DEFAULT_PAGE_SIZE);
+
+  return {
+    items: truncated,
+    hasMore,
+    next_page_params: response.next_page_params
+      ? JSON.stringify(response.next_page_params)
+      : null,
+  };
+}
+
 /**
  * /addresses ENDPOINTS
  * - GET /addresses => Get native coin holders list
@@ -219,18 +244,28 @@ export const getAddressTokenTransfers = createTool({
  */
 export const getAddressInternalTransactions = createTool({
   name: "getAddressInternalTransactions",
-  description: "Get internal (trace-level) transactions for an address, including contract-to-contract calls and ETH transfers within transactions.",
+  description: "Get internal (trace-level) transactions for an address, including contract-to-contract calls and ETH transfers within transactions. Returns at most 20 items; use the `next_page_params` value to paginate.",
   supportedChains: supportedChains,
   parameters: z.object({
     chain: chainSchema,
     address: addressSchema,
+    next_page_params: z.string().optional().describe("Opaque pagination cursor from a previous response. Pass exactly as received to fetch the next page."),
   }),
   execute: async (_, args) => {
-    const { chain, address } = args;
-    return await fetchFromBlockscoutV2(
+    const { chain, address, next_page_params } = args;
+    const query: Record<string, string> = {};
+    if (next_page_params) {
+      const parsed = JSON.parse(next_page_params);
+      for (const [k, v] of Object.entries(parsed)) {
+        query[k] = String(v);
+      }
+    }
+    const response = await fetchFromBlockscoutV2(
       chain as SupportedChain,
       `/addresses/${address}/internal-transactions`,
+      query,
     );
+    return compactItems(response);
   },
 });
 
@@ -263,18 +298,28 @@ export const getAddressLogs = createTool({
  */
 export const getAddressBlocksValidated = createTool({
   name: "getAddressBlocksValidated",
-  description: "Get blocks validated (proposed) by a specific validator address.",
+  description: "Get blocks validated (proposed) by a specific validator address. Returns at most 20 items; use the `next_page_params` value to paginate.",
   supportedChains: supportedChains,
   parameters: z.object({
     chain: chainSchema,
     address: addressSchema,
+    next_page_params: z.string().optional().describe("Opaque pagination cursor from a previous response. Pass exactly as received to fetch the next page."),
   }),
   execute: async (_, args) => {
-    const { chain, address } = args;
-    return await fetchFromBlockscoutV2(
+    const { chain, address, next_page_params } = args;
+    const query: Record<string, string> = {};
+    if (next_page_params) {
+      const parsed = JSON.parse(next_page_params);
+      for (const [k, v] of Object.entries(parsed)) {
+        query[k] = String(v);
+      }
+    }
+    const response = await fetchFromBlockscoutV2(
       chain as SupportedChain,
       `/addresses/${address}/blocks-validated`,
+      query,
     );
+    return compactItems(response);
   },
 });
 
@@ -417,18 +462,28 @@ export const getAddressNFTs = createTool({
  */
 export const getAddressNFTCollections = createTool({
   name: "getAddressNFTCollections",
-  description: "Get NFTs owned by an address, grouped by collection (ERC721/ERC1155).",
+  description: "Get NFTs owned by an address, grouped by collection (ERC721/ERC1155). Returns at most 20 items; use the `next_page_params` value to paginate.",
   supportedChains: supportedChains,
   parameters: z.object({
     chain: chainSchema,
     address: addressSchema,
+    next_page_params: z.string().optional().describe("Opaque pagination cursor from a previous response. Pass exactly as received to fetch the next page."),
   }),
   execute: async (_, args) => {
-    const { chain, address } = args;
-    return await fetchFromBlockscoutV2(
+    const { chain, address, next_page_params } = args;
+    const query: Record<string, string> = {};
+    if (next_page_params) {
+      const parsed = JSON.parse(next_page_params);
+      for (const [k, v] of Object.entries(parsed)) {
+        query[k] = String(v);
+      }
+    }
+    const response = await fetchFromBlockscoutV2(
       chain as SupportedChain,
       `/addresses/${address}/nft/collections`,
+      query,
     );
+    return compactItems(response);
   },
 });
 

--- a/packages/shared/erc20/tools.ts
+++ b/packages/shared/erc20/tools.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { createTool } from "../client.js";
-import { Address, erc20Abi, formatUnits } from "viem";
+import { Address, erc20Abi, formatUnits, getAddress } from "viem";
 import { erc20Chains } from "./constants.js";
+
+/** Normalize an address string to proper EIP-55 checksum so mixed-case input never fails. */
+const normalizeAddress = (addr: string): Address => getAddress(addr.toLowerCase());
 
 const getAllowanceParameters = z.object({
   token: z.string().describe("The token address"),
@@ -68,6 +71,9 @@ export const getAllowanceTool = createTool({
   parameters: getAllowanceParameters,
   execute: async (client, args) => {
     const { token, owner, spender, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
+    const ownerAddr = normalizeAddress(owner);
+    const spenderAddr = normalizeAddress(spender);
     const chains = client.filterSupportedChains(erc20Chains, chainId);
 
     const allowances = await Promise.all(
@@ -75,15 +81,15 @@ export const getAllowanceTool = createTool({
         const publicClient = client.getPublicClient(chain.id);
         try {
           const decimals = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "decimals",
           });
           const allowance = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "allowance",
-            args: [owner as Address, spender as Address],
+            args: [ownerAddr, spenderAddr],
           });
 
           return {
@@ -111,6 +117,8 @@ export const getBalanceOfTool = createTool({
   parameters: getBalanceOfParameters,
   execute: async (client, args) => {
     const { token, owner, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
+    const ownerAddr = normalizeAddress(owner);
     const chains = client.filterSupportedChains(erc20Chains, chainId);
 
     const balances = await Promise.all(
@@ -118,15 +126,15 @@ export const getBalanceOfTool = createTool({
         const publicClient = client.getPublicClient(chain.id);
         try {
           const decimals = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "decimals",
           });
           const balance = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "balanceOf",
-            args: [owner as Address],
+            args: [ownerAddr],
           });
 
           return {
@@ -153,6 +161,7 @@ export const getTotalSupplyTool = createTool({
   parameters: getTotalSupplyParameters,
   execute: async (client, args) => {
     const { token, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
     const chains = client.filterSupportedChains(erc20Chains, chainId);
 
     const supplies = await Promise.all(
@@ -160,12 +169,12 @@ export const getTotalSupplyTool = createTool({
         const publicClient = client.getPublicClient(chain.id);
         try {
           const decimals = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "decimals",
           });
           const totalSupply = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "totalSupply",
           });
@@ -194,6 +203,7 @@ export const getDecimalsTool = createTool({
   parameters: getDecimalsParameters,
   execute: async (client, args) => {
     const { token, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
     const chains = client.filterSupportedChains(erc20Chains, chainId);
 
     const tokenDecimals = await Promise.all(
@@ -201,7 +211,7 @@ export const getDecimalsTool = createTool({
         const publicClient = client.getPublicClient(chain.id);
         try {
           const decimals = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "decimals",
           });
@@ -230,6 +240,7 @@ export const getNameTool = createTool({
   parameters: getNameParameters,
   execute: async (client, args) => {
     const { token, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
     const chains = client.filterSupportedChains(erc20Chains, chainId);
 
     const names = await Promise.all(
@@ -237,7 +248,7 @@ export const getNameTool = createTool({
         const publicClient = client.getPublicClient(chain.id);
         try {
           const name = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "name",
           });
@@ -266,6 +277,7 @@ export const getSymbolTool = createTool({
   parameters: getSymbolParameters,
   execute: async (client, args) => {
     const { token, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
     const chains = client.filterSupportedChains(erc20Chains, chainId);
 
     const symbols = await Promise.all(
@@ -273,7 +285,7 @@ export const getSymbolTool = createTool({
         const publicClient = client.getPublicClient(chain.id);
         try {
           const symbol = await publicClient.readContract({
-            address: token as Address,
+            address: tokenAddr,
             abi: erc20Abi,
             functionName: "symbol",
           });
@@ -303,25 +315,26 @@ export const getTokenMetadataTool = createTool({
   parameters: tokenMetadataParameters,
   execute: async (client, args) => {
     const { token, chainId } = args;
+    const tokenAddr = normalizeAddress(token);
     const publicClient = client.getPublicClient(chainId);
     const [name, symbol, decimals, totalSupply] = await Promise.all([
       publicClient.readContract({
-        address: token as Address,
+        address: tokenAddr,
         abi: erc20Abi,
         functionName: "name",
       }),
       publicClient.readContract({
-        address: token as Address,
+        address: tokenAddr,
         abi: erc20Abi,
         functionName: "symbol",
       }),
       publicClient.readContract({
-        address: token as Address,
+        address: tokenAddr,
         abi: erc20Abi,
         functionName: "decimals",
       }),
       publicClient.readContract({
-        address: token as Address,
+        address: tokenAddr,
         abi: erc20Abi,
         functionName: "totalSupply",
       }),

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -32,6 +32,7 @@ import { zrouterTools } from "./zrouter/index.js";
 import { wnsTools } from "./wns/index.js";
 import { x402Tools } from "./x402/index.js";
 import { twitterTools } from "./twitter/index.js";
+import { resolveTokenTools } from "./resolveToken/index.js";
 import { assertOkResponse } from "./utils/fetch.js";
 
 const allTools = async ({
@@ -88,7 +89,8 @@ const allTools = async ({
     ...zammTools(),
     ...zrouterTools(),
     ...wnsTools(),
-    ...x402Tools()
+    ...x402Tools(),
+    ...resolveTokenTools(),
   ];
 
   if (perplexityApiKey) {
@@ -169,5 +171,6 @@ export {
   wnsTools,
   x402Tools,
   twitterTools,
+  resolveTokenTools,
   assertOkResponse
 };

--- a/packages/shared/resolveToken/constants.ts
+++ b/packages/shared/resolveToken/constants.ts
@@ -1,0 +1,107 @@
+import {
+  mainnet,
+  arbitrum,
+  base,
+  optimism,
+} from "viem/chains";
+import type { Address } from "viem";
+
+export const resolveTokenChains = [mainnet, arbitrum, base, optimism];
+
+type TokenEntry = {
+  address: Address;
+  decimals: number;
+  name: string;
+};
+
+type TokenMap = Record<number, TokenEntry>;
+
+/**
+ * Well-known tokens indexed by upper-cased symbol, then by chainId.
+ *
+ * Only tokens that are widely referenced in LLM tool-calling flows are
+ * included here. The list is intentionally small so the mapping stays
+ * accurate and easy to audit.
+ */
+export const TOKEN_REGISTRY: Record<string, TokenMap> = {
+  USDC: {
+    [mainnet.id]: { address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", decimals: 6, name: "USD Coin" },
+    [arbitrum.id]: { address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", decimals: 6, name: "USD Coin" },
+    [base.id]: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", decimals: 6, name: "USD Coin" },
+    [optimism.id]: { address: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", decimals: 6, name: "USD Coin" },
+  },
+  USDT: {
+    [mainnet.id]: { address: "0xdAC17F958D2ee523a2206206994597C13D831ec7", decimals: 6, name: "Tether USD" },
+    [arbitrum.id]: { address: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9", decimals: 6, name: "Tether USD" },
+    [base.id]: { address: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2", decimals: 6, name: "Tether USD" },
+    [optimism.id]: { address: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58", decimals: 6, name: "Tether USD" },
+  },
+  DAI: {
+    [mainnet.id]: { address: "0x6B175474E89094C44Da98b954EedeAC495271d0F", decimals: 18, name: "Dai Stablecoin" },
+    [arbitrum.id]: { address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1", decimals: 18, name: "Dai Stablecoin" },
+    [base.id]: { address: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", decimals: 18, name: "Dai Stablecoin" },
+    [optimism.id]: { address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1", decimals: 18, name: "Dai Stablecoin" },
+  },
+  WETH: {
+    [mainnet.id]: { address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", decimals: 18, name: "Wrapped Ether" },
+    [arbitrum.id]: { address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", decimals: 18, name: "Wrapped Ether" },
+    [base.id]: { address: "0x4200000000000000000000000000000000000006", decimals: 18, name: "Wrapped Ether" },
+    [optimism.id]: { address: "0x4200000000000000000000000000000000000006", decimals: 18, name: "Wrapped Ether" },
+  },
+  WBTC: {
+    [mainnet.id]: { address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", decimals: 8, name: "Wrapped BTC" },
+    [arbitrum.id]: { address: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f", decimals: 8, name: "Wrapped BTC" },
+    [base.id]: { address: "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c", decimals: 8, name: "Wrapped BTC" },
+    [optimism.id]: { address: "0x68f180fcCe6836688e9084f035309E29Bf0A2095", decimals: 8, name: "Wrapped BTC" },
+  },
+  LINK: {
+    [mainnet.id]: { address: "0x514910771AF9Ca656af840dff83E8264EcF986CA", decimals: 18, name: "ChainLink Token" },
+    [arbitrum.id]: { address: "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4", decimals: 18, name: "ChainLink Token" },
+    [base.id]: { address: "0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196", decimals: 18, name: "ChainLink Token" },
+    [optimism.id]: { address: "0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6", decimals: 18, name: "ChainLink Token" },
+  },
+  UNI: {
+    [mainnet.id]: { address: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984", decimals: 18, name: "Uniswap" },
+    [arbitrum.id]: { address: "0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0", decimals: 18, name: "Uniswap" },
+    [optimism.id]: { address: "0x6fd9d7AD17242c41f7131d257212c54A0e816691", decimals: 18, name: "Uniswap" },
+  },
+  AAVE: {
+    [mainnet.id]: { address: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9", decimals: 18, name: "Aave Token" },
+    [arbitrum.id]: { address: "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196", decimals: 18, name: "Aave Token" },
+    [optimism.id]: { address: "0x76FB31fb4af56892A25e32cFC43De717950c9278", decimals: 18, name: "Aave Token" },
+  },
+  cbBTC: {
+    [mainnet.id]: { address: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf", decimals: 8, name: "Coinbase Wrapped BTC" },
+    [base.id]: { address: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf", decimals: 8, name: "Coinbase Wrapped BTC" },
+  },
+  cbETH: {
+    [mainnet.id]: { address: "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704", decimals: 18, name: "Coinbase Wrapped Staked ETH" },
+    [base.id]: { address: "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22", decimals: 18, name: "Coinbase Wrapped Staked ETH" },
+    [optimism.id]: { address: "0xadDb6A0412DE1BA0F936DCaeb8Aaa24578dcF3B2", decimals: 18, name: "Coinbase Wrapped Staked ETH" },
+  },
+  stETH: {
+    [mainnet.id]: { address: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84", decimals: 18, name: "Lido Staked Ether" },
+  },
+  wstETH: {
+    [mainnet.id]: { address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", decimals: 18, name: "Wrapped liquid staked Ether 2.0" },
+    [arbitrum.id]: { address: "0x5979D7b546E38E9Ab8304709A1645468b2494aA4", decimals: 18, name: "Wrapped liquid staked Ether 2.0" },
+    [base.id]: { address: "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452", decimals: 18, name: "Wrapped liquid staked Ether 2.0" },
+    [optimism.id]: { address: "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb", decimals: 18, name: "Wrapped liquid staked Ether 2.0" },
+  },
+  rETH: {
+    [mainnet.id]: { address: "0xae78736Cd615f374D3085123A210448E74Fc6393", decimals: 18, name: "Rocket Pool ETH" },
+    [arbitrum.id]: { address: "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8", decimals: 18, name: "Rocket Pool ETH" },
+    [base.id]: { address: "0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c", decimals: 18, name: "Rocket Pool ETH" },
+    [optimism.id]: { address: "0x9Bcef72be871e61ED4fBbc7630889beE758eb81D", decimals: 18, name: "Rocket Pool ETH" },
+  },
+  GRT: {
+    [mainnet.id]: { address: "0xc944E90C64B2c07662A292be6244BDf05Cda44a7", decimals: 18, name: "Graph Token" },
+    [arbitrum.id]: { address: "0x9623063377AD1B27544C965cCd7342f7EA7e88C7", decimals: 18, name: "Graph Token" },
+  },
+  ARB: {
+    [arbitrum.id]: { address: "0x912CE59144191C1204E64559FE8253a0e49E6548", decimals: 18, name: "Arbitrum" },
+  },
+  OP: {
+    [optimism.id]: { address: "0x4200000000000000000000000000000000000042", decimals: 18, name: "Optimism" },
+  },
+};

--- a/packages/shared/resolveToken/index.ts
+++ b/packages/shared/resolveToken/index.ts
@@ -1,0 +1,6 @@
+import { BaseTool, createToolCollection } from "../client.js";
+import { resolveTokenTool } from "./tools.js";
+
+export function resolveTokenTools(): BaseTool[] {
+  return createToolCollection([resolveTokenTool]);
+}

--- a/packages/shared/resolveToken/tools.ts
+++ b/packages/shared/resolveToken/tools.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { createTool } from "../client.js";
+import { resolveTokenChains, TOKEN_REGISTRY } from "./constants.js";
+
+const resolveTokenParameters = z.object({
+  symbol: z.string().describe("Token symbol (e.g. 'USDC', 'DAI', 'WETH')"),
+  chainId: z.number().describe("Chain ID to resolve on (1 = Ethereum, 8453 = Base, 42161 = Arbitrum, 10 = Optimism)"),
+});
+
+export const resolveTokenTool = createTool({
+  name: "resolveToken",
+  description:
+    "Resolve a token symbol (e.g. 'USDC', 'DAI', 'WETH') to its contract address, decimals, and name on a specific chain. Use this before calling tools like getBalanceOf, intentApprove, or intentTransfer when you only have a symbol.",
+  supportedChains: resolveTokenChains,
+  parameters: resolveTokenParameters,
+  execute: async (_client, args) => {
+    const { symbol, chainId } = args;
+    const key = symbol.toUpperCase();
+    const tokenMap = TOKEN_REGISTRY[key] ?? TOKEN_REGISTRY[symbol];
+
+    if (!tokenMap) {
+      throw new Error(
+        `Unknown token symbol "${symbol}". Supported symbols: ${Object.keys(TOKEN_REGISTRY).join(", ")}`,
+      );
+    }
+
+    const entry = tokenMap[chainId];
+    if (!entry) {
+      const supportedChainIds = Object.keys(tokenMap).map(Number);
+      throw new Error(
+        `Token ${symbol} is not available on chain ${chainId}. Available on chains: ${supportedChainIds.join(", ")}`,
+      );
+    }
+
+    return {
+      symbol: key,
+      chainId,
+      address: entry.address,
+      decimals: entry.decimals,
+      name: entry.name,
+    };
+  },
+});

--- a/packages/shared/rpc/tools.test.ts
+++ b/packages/shared/rpc/tools.test.ts
@@ -203,7 +203,8 @@ describe("RPC Tools - Real Chain Calls", () => {
       expect(result).toHaveProperty("hash");
       expect(result).toHaveProperty("number");
       expect(result).toHaveProperty("timestamp");
-      expect(result).toHaveProperty("transactions");
+      expect(result).toHaveProperty("transactionCount");
+      expect(result).not.toHaveProperty("transactions");
       expect(result.number).toBe("1000000");
     });
 

--- a/packages/shared/rpc/tools.ts
+++ b/packages/shared/rpc/tools.ts
@@ -122,9 +122,16 @@ const getTransactionCount = createTool({
 });
 
 // Block Tools
+const compactBlock = (block: any) => {
+  const cleaned = clean(block);
+  const txCount = Array.isArray(cleaned.transactions) ? cleaned.transactions.length : 0;
+  const { transactions, ...rest } = cleaned;
+  return { ...rest, transactionCount: txCount };
+};
+
 const getBlock = createTool({
   name: "getBlock",
-  description: "Get information about a block including timestamp, transactions, gas used, etc. Returns the latest block if no block number is specified.",
+  description: "Get a compact summary of a block (number, timestamp, gas used, transaction count). Full transactions are omitted to keep the response small. Returns the latest block if no block number is specified.",
   supportedChains,
   parameters: z.object({
     blockNumber: z.number().optional().describe("The block number to fetch. Omit to get the latest block."),
@@ -137,11 +144,11 @@ const getBlock = createTool({
       const block = await publicClient.getBlock({
         blockNumber: BigInt(args.blockNumber),
       });
-      return clean(block);
+      return compactBlock(block);
     }
 
     const block = await publicClient.getBlock();
-    return clean(block);
+    return compactBlock(block);
   },
 });
 

--- a/packages/shared/transfer/intents.ts
+++ b/packages/shared/transfer/intents.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { AgentekClient, createTool, Intent } from "../client.js";
-import { arbitrum, base, mainnet, sepolia } from "viem/chains";
+import { arbitrum, base, mainnet, optimism, sepolia } from "viem/chains";
 import {
   Address,
   encodeFunctionData,
@@ -12,7 +12,7 @@ import {
 import { addressSchema } from "../utils.js";
 import { resolveENSTool } from "../ens/tools.js";
 
-const intentTransferChains = [mainnet, arbitrum, base, sepolia];
+const intentTransferChains = [mainnet, arbitrum, base, optimism, sepolia];
 const intentTransferParameters = z.object({
   token: addressSchema.describe("The token contract address (0x...), or 0x0000000000000000000000000000000000000000 for native ETH"),
   amount: z.string().describe("Amount to transfer in human-readable units (e.g. '1.5' for 1.5 tokens). Decimals are resolved automatically."),
@@ -187,7 +187,7 @@ const intentTransferFromParameters = z.object({
   chainId: z.number().optional().describe("Chain ID to transfer on (e.g. 1, 42161, 8453). If omitted, automatically selects the cheapest chain where the 'from' address has sufficient balance."),
 });
 
-const intentTransferFromChains = [mainnet, arbitrum, base, sepolia];
+const intentTransferFromChains = [mainnet, arbitrum, base, optimism, sepolia];
 
 export const intentTransferFromTool = createTool({
   name: "intentTransferFrom",

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,17 +1,16 @@
-import { Address } from "viem";
+import { Address, getAddress } from "viem";
 import { z } from "zod";
 import { isAddress } from "viem/utils";
 
 export const addressSchema = z.string().transform((val, ctx) => {
-  if (!isAddress(val)) {
+  if (!isAddress(val, { strict: false })) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "Invalid Ethereum address",
     });
-    // stop here
     return z.NEVER;
   }
-  return val as Address; // output is Address
+  return getAddress(val) as Address;
 });
 
 export const clean = (obj: any): any => {


### PR DESCRIPTION
…Optimism support

- Compact blockscout responses (getAddressInternalTransactions, getAddressBlocksValidated, getAddressNFTCollections) to 20 items max with hasMore flag and pagination cursor
- Compact getBlock to return summary without full transactions array
- Add resolveToken tool for symbol→address/decimals/name resolution across Ethereum, Base, Arbitrum, and Optimism
- Normalize ERC20 tool addresses to proper EIP-55 checksum so mixed-case inputs no longer fail validation
- Add Optimism (chainId 10) to intentTransfer and intentTransferFrom